### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-#Initializing Submodules
+# Initializing Submodules
 ```
 git clone git@github.com:bittorrenttorque/oneclick.git
 git submodule init
 git submodule update
 ```
-#Updating Submodules
+# Updating Submodules
 Use this when you've changed code in one of the submodules, commited it, and now want to use that new code in this project.
 ```
 git submodule -q foreach git pull -q origin master
 ```
 
-#Build/Install (Development)  
+# Build/Install (Development)  
 Chrome -> Tools -> Extensions  
 Enable *Developer Mode*  
 Click *Load Unpacked Extension* and select this project directory  
 
-#License
+# License
 Copyright 2012 Patrick Williams, BitTorrent Inc.
 http://torque.bittorrent.com/
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
